### PR TITLE
Provide column names as vector, not CSV

### DIFF
--- a/R/model_graphs.R
+++ b/R/model_graphs.R
@@ -31,7 +31,7 @@ calmr_model_graph <- function(
   # aggregate data
   x <- data.table::setDT(x)[trial == t,
     list("value" = mean(value)),
-    by = "s1,s2"
+    by = c("s1","s2")
   ]
   net <- ggnetwork::ggnetwork(network::as.network(x, loops = loops),
     layout = "circle",

--- a/R/model_parsers.R
+++ b/R/model_parsers.R
@@ -226,9 +226,9 @@
 # type is the type of data
 .aggregate_results_data_table <- function(dat, model, type) {
   value <- time <- NULL # local binding
-  common_terms <- "group,phase,trial_type,trial,block_size,s1"
+  common_terms <- c("group","phase","trial_type","trial","block_size","s1")
   fmap <- formula_map()
-  form <- paste0(c(common_terms, fmap[[model]][[type]]), collapse = ",")
+  form <- c(common_terms, fmap[[model]][[type]])
   dat <- data.table::data.table(dat)
   if (!("time" %in% names(dat))) {
     data.table::setDT(dat)[, list("value" = mean(value)), by = form]

--- a/vignettes/calmr_fits.Rmd
+++ b/vignettes/calmr_fits.Rmd
@@ -66,7 +66,7 @@ so we know what to aim for.
 ```{r}
 pati_summ <- setDT(pati)[,
   list("rpert" = mean(rpert)),
-  by = "block,us,response"
+  by = c("block","us","response")
 ]
 # set order (relevant for the future)
 setorder(pati_summ, block, response, us)
@@ -163,7 +163,7 @@ my_model_function <- function(pars, exper, full = FALSE) {
     (response == "np" | (response == "lp" &
       mapply(grepl, s1, trial_type)))]
   # aggregate
-  responses <- responses[, list(value = mean(value)), by = "block,s2,response"]
+  responses <- responses[, list(value = mean(value)), by = c("block","s2","response")]
   if (full) {
     return(responses)
   }


### PR DESCRIPTION
data.table is considering deprecating this approach to specifying `by=`, namely, as a comma-separated string of columns, because of the inconsistency it induces.

Please follow up in https://github.com/Rdatatable/data.table/issues/4357 if you have further input about this plan.